### PR TITLE
StreamReader in Python3.5 sets to None in connection_lost method. Occ…

### DIFF
--- a/aioamqp/frame.py
+++ b/aioamqp/frame.py
@@ -405,6 +405,8 @@ class AmqpResponse:
     def read_frame(self):
         """Decode the frame"""
         try:
+            if not self.reader:
+                raise exceptions.AmqpClosedConnection()
             data = yield from self.reader.readexactly(7)
         except (asyncio.IncompleteReadError, socket.error) as ex:
             raise exceptions.AmqpClosedConnection() from ex


### PR DESCRIPTION
…asionally, this leads to endless exception throw.

This fix may close issue #115.